### PR TITLE
fix: support a single audience/campaign per selector in fragment manifests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -923,11 +923,15 @@ function parseCampaignManifest(entries) {
   ))
     .map(aggregateEntries('campaign', ['campaign', 'url']))
     .map((e) => {
-      const campaigns = e.campaign;
+      // A selector with a single campaign leaves `campaign`/`url` as scalars
+      // (aggregateEntries only builds arrays for multi-value selectors), so
+      // normalize to arrays before iterating.
+      const campaigns = [].concat(e.campaign);
+      const urls = [].concat(e.url);
       delete e.campaign;
       e.campaigns = {};
       campaigns.forEach((a, i) => {
-        e.campaigns[toClassName(a)] = e.url[i];
+        e.campaigns[toClassName(a)] = urls[i];
       });
       delete e.url;
       return e;
@@ -1003,11 +1007,15 @@ function parseAudienceManifest(entries) {
   ))
     .map(aggregateEntries('audience', ['audience', 'url']))
     .map((e) => {
-      const audiences = e.audience;
+      // A selector with a single audience leaves `audience`/`url` as scalars
+      // (aggregateEntries only builds arrays for multi-value selectors), so
+      // normalize to arrays before iterating.
+      const audiences = [].concat(e.audience);
+      const urls = [].concat(e.url);
       delete e.audience;
       e.audiences = {};
       audiences.forEach((a, i) => {
-        e.audiences[toClassName(a)] = e.url[i];
+        e.audiences[toClassName(a)] = urls[i];
       });
       delete e.url;
       return e;

--- a/tests/audiences.test.js
+++ b/tests/audiences.test.js
@@ -165,6 +165,11 @@ test.describe('Fragment-level audiences', () => {
     expect(await page.locator('.fragment').textContent()).toContain('Hello v1!');
   });
 
+  test('Supports a single audience per selector.', async ({ page }) => {
+    await goToAndRunAudience(page, '/tests/fixtures/audiences/fragment-level--single');
+    expect(await page.locator('.fragment').textContent()).toContain('Hello v1!');
+  });
+
   test('Ignores invalid manifest url.', async ({ page }) => {
     await goToAndRunAudience(page, '/tests/fixtures/audiences/fragment-level--invalid-url');
     expect(await page.locator('.fragment').textContent()).toContain('Hello World!');

--- a/tests/campaigns.test.js
+++ b/tests/campaigns.test.js
@@ -173,6 +173,11 @@ test.describe('Fragment-level campaigns', () => {
     expect(await page.locator('.fragment').textContent()).toContain('Hello v1!');
   });
 
+  test('Supports a single campaign per selector.', async ({ page }) => {
+    await goToAndRunCampaign(page, '/tests/fixtures/campaigns/fragment-level--single?campaign=foo');
+    expect(await page.locator('.fragment').textContent()).toContain('Hello v1!');
+  });
+
   test('Ignores invalid manifest url.', async ({ page }) => {
     await goToAndRunCampaign(page, '/tests/fixtures/campaigns/fragment-level--invalid-url?campaign=foo');
     expect(await page.locator('.fragment').textContent()).toContain('Hello World!');

--- a/tests/fixtures/audiences/fragment-level--single.html
+++ b/tests/fixtures/audiences/fragment-level--single.html
@@ -1,0 +1,23 @@
+<html>
+<head>
+  <script type="module" src="/tests/fixtures/scripts.js"></script>
+  <meta name="audience-manifest" content="/tests/fixtures/audiences/fragments--single.json"/>
+  <script>
+    window.AUDIENCES = {
+      foo: () => true,
+      bar: () => false,
+    }
+  </script>
+</head>
+<body>
+  <main>
+    <div>
+      <div>
+        <div class="fragment">
+          <div>Hello World!</div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/audiences/fragments--single.json
+++ b/tests/fixtures/audiences/fragments--single.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+      {
+          "Page": "/tests/fixtures/audiences/fragment-level--single",
+          "Audience": "Foo",
+          "Selector": ".fragment",
+          "Url": "/tests/fixtures/audiences/variant-1"
+      }
+  ],
+  ":type": "sheet"
+}

--- a/tests/fixtures/campaigns/fragment-level--single.html
+++ b/tests/fixtures/campaigns/fragment-level--single.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <script type="module" src="/tests/fixtures/scripts.js"></script>
+  <meta name="campaign-manifest" content="/tests/fixtures/campaigns/fragments--single.json"/>
+</head>
+<body>
+  <main>
+    <div>
+      <div>
+        <div class="fragment">
+          <div>Hello World!</div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/campaigns/fragments--single.json
+++ b/tests/fixtures/campaigns/fragments--single.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+      {
+          "Page": "/tests/fixtures/campaigns/fragment-level--single",
+          "Campaign": "Foo",
+          "Selector": ".fragment",
+          "Url": "/tests/fixtures/campaigns/variant-1"
+      }
+  ],
+  ":type": "sheet"
+}


### PR DESCRIPTION
## Problem

A fragment-level **Audience Manifest** (or **Campaign Manifest**) with a **single audience/campaign per selector** crashes the plugin.

`parseAudienceManifest` / `parseCampaignManifest` call `audiences.forEach(...)` / `campaigns.forEach(...)`, but `aggregateEntries` only produces an **array** when a selector has *multiple* values — a selector with a single value leaves `audience`/`campaign` (and `url`) as a **scalar string**. `String.prototype.forEach` doesn't exist, so it throws `audiences.forEach is not a function`, which aborts `loadEager` and leaves the fragment un-personalized (`window.hlx.audiences` / `.campaigns` never gets set).

Every existing manifest fixture uses *two* audiences/campaigns per selector, so this single-value path was never exercised.

## Fix

Normalize `audience`/`campaign` and `url` to arrays with `[].concat(...)` before iterating — a no-op for the existing multi-value case, correct for the single-value case.

## Tests

Adds fragment-level fixtures + tests for a **single audience** and a **single campaign** per selector. They fail red before this change (`waitForNamespace` times out because the plugin threw) and pass after. Full `audiences` + `campaigns` suites green (**46 passed**), lint clean.

---

Found while building a "bring your own decision engine" personalization integration, where each slot's manifest carries exactly one (remote) audience — a common shape for per-slot personalization, so it's worth handling out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
