### PR TITLE
fix: resolve multi-word audience/campaign names at page level

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,9 +216,13 @@ export function getMetadata(name) {
 /**
  * Gets all the metadata elements that are in the given scope.
  * @param {String} scope The scope/prefix for the metadata
+ * @param {Function} keyFn Transforms each metadata key. Defaults to `toCamelCase`
+ *   (config props like `startDate`, `requiresConsent`); pass `toClassName` to
+ *   preserve multi-word *names* (audience/campaign names must stay class-name to
+ *   match the project config + resolution).
  * @returns a map of key/value pairs for the given scope
  */
-export function getAllMetadata(scope) {
+export function getAllMetadata(scope, keyFn = toCamelCase) {
   const value = getMetadata(scope);
   const metaTags = document.head.querySelectorAll(`meta[name^="${scope}"], meta[property^="${scope}:"]`);
   return [...metaTags].reduce((res, meta) => {
@@ -228,8 +232,7 @@ export function getAllMetadata(scope) {
         : meta.getAttribute('property').substring(scope.length + 1),
     );
 
-    const camelCaseKey = toCamelCase(key);
-    res[camelCaseKey] = meta.getAttribute('content');
+    res[keyFn(key)] = meta.getAttribute('content');
     return res;
   }, value ? { value } : {});
 }
@@ -611,8 +614,12 @@ async function applyAllModifications(
 
   const configs = [];
 
-  // Full-page modifications
-  const pageMetadata = getAllMetadata(type);
+  // Full-page modifications. Experiments key their metadata by camelCased config
+  // props (`startDate`, `requiresConsent`, …); audiences/campaigns key by
+  // audience/campaign *name*, which must stay class-name to match the project
+  // config + resolution (as section- and fragment-level already do).
+  const keyFn = type === pluginOptions.experimentsMetaTagPrefix ? toCamelCase : toClassName;
+  const pageMetadata = getAllMetadata(type, keyFn);
   const pageNS = await modificationsHandler(
     document.querySelector('main'),
     pageMetadata,

--- a/tests/audiences.test.js
+++ b/tests/audiences.test.js
@@ -101,6 +101,11 @@ test.describe('Page-level audiences', () => {
     );
   });
 
+  test('Supports a multi-word audience name.', async ({ page }) => {
+    await goToAndRunAudience(page, '/tests/fixtures/audiences/page-level--hyphenated');
+    expect(await page.locator('main').textContent()).toContain('Hello v1!');
+  });
+
   test('triggers a DOM event with the audience detail', async ({ page }) => {
     const fn = await waitForDomEvent(page, 'aem:experimentation');
     await page.goto('/tests/fixtures/audiences/page-level');

--- a/tests/campaigns.test.js
+++ b/tests/campaigns.test.js
@@ -50,6 +50,11 @@ test.describe('Page-level campaigns', () => {
     expect(await page.locator('main').textContent()).toContain('Hello v2!');
   });
 
+  test('Supports a multi-word campaign name.', async ({ page }) => {
+    await goToAndRunCampaign(page, '/tests/fixtures/campaigns/page-level--hyphenated?campaign=black-friday');
+    expect(await page.locator('main').textContent()).toContain('Hello v1!');
+  });
+
   test('Ignores invalid campaigns references in the query parameters.', async ({ page }) => {
     await goToAndRunCampaign(page, '/tests/fixtures/campaigns/page-level?campaign=baz');
     expect(await page.locator('main').textContent()).toContain('Hello World!');

--- a/tests/fixtures/audiences/page-level--hyphenated.html
+++ b/tests/fixtures/audiences/page-level--hyphenated.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+  <meta name="audience-returning-visitor" content="/tests/fixtures/audiences/variant-1"/>
+  <script>
+    window.AUDIENCES = {
+      'returning-visitor': () => true,
+    }
+  </script>
+  <script type="module" src="/tests/fixtures/scripts.js"></script>
+</head>
+<body>
+  <main>
+    <div>Hello World!</div>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/campaigns/page-level--hyphenated.html
+++ b/tests/fixtures/campaigns/page-level--hyphenated.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+  <meta name="campaign-black-friday" content="/tests/fixtures/campaigns/variant-1"/>
+  <script type="module" src="/tests/fixtures/scripts.js"></script>
+</head>
+<body>
+  <main>
+    <div>Hello World!</div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Problem

A **page-level** audience or campaign with a **multi-word name** (e.g. `returning-visitor`, `black-friday`) resolves its *membership* but never serves the variant — the experience is silently dropped.

Root cause: page-level metadata is read with `getAllMetadata`, which **camelCases** keys (`audience-returning-visitor` → `returningVisitor`). Names are then matched + looked up in **class-name** form, and `toClassName('returningVisitor')` → `returningvisitor` (the word boundary is lost), so it matches neither the project config key (`returning-visitor`) nor the camelCase one. Section- and fragment-level already key names by class-name, so they work — only page-level is affected.

## Fix

- `getAllMetadata(scope, keyFn = toCamelCase)` — an optional key transform. The default is unchanged, so **experiments keep their camelCased config props** (`startDate`, `requiresConsent`, …).
- `applyAllModifications` passes `toClassName` for **audience/campaign** page metadata (experiments keep `toCamelCase`), matching how section- and fragment-level already read names.
- Config readers (`getAudienceConfig` / `getCampaignConfig`) are **unchanged** — they already handle class-name keys.

## Tests

Adds page-level fixtures + tests for a multi-word audience and a multi-word campaign name. They fail red before this change (the variant isn't served) and pass after. **Full suite green — 101 tests, including experiments — no regression.**

---

Found while building a bring-your-own-engine integration (see #64) — this is bug #2 from that RFC. It removes the need for hyphen-free tokens at page level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
